### PR TITLE
[runtime] fix snack fetching

### DIFF
--- a/runtime/src/App.tsx
+++ b/runtime/src/App.tsx
@@ -374,9 +374,12 @@ export default class App extends React.Component<Props, State> {
   };
 
   _uploadPreviewToS3 = async (asset: string, height: number, width: number) => {
+    // FIXME: Right now always using production snackpub server for custom snack-runtime.
+    // We should find a way to support both custom snack-runtime and formal snack-runtime serving from EAS Update.
     const url = `${
       Constants.manifest?.extra?.cloudEnv !== 'production'
-        ? API_SERVER_URL_STAGING
+        // ? API_SERVER_URL_STAGING
+        ? API_SERVER_URL_PROD
         : API_SERVER_URL_PROD
     }/--/api/v2/snack/uploadPreview`;
     const body = JSON.stringify({ asset, height, width });

--- a/runtime/src/App.tsx
+++ b/runtime/src/App.tsx
@@ -30,7 +30,7 @@ import {
   extractSnackIdentifierFromSnackUrl,
 } from './utils/SnackUrlUtils';
 
-const API_SERVER_URL_STAGING = 'https://staging.exp.host';
+// const API_SERVER_URL_STAGING = 'https://staging.exp.host';
 const API_SERVER_URL_PROD = 'https://exp.host';
 
 export type SnackState = 'loading' | 'finished';
@@ -378,8 +378,8 @@ export default class App extends React.Component<Props, State> {
     // We should find a way to support both custom snack-runtime and formal snack-runtime serving from EAS Update.
     const url = `${
       Constants.manifest?.extra?.cloudEnv !== 'production'
-        // ? API_SERVER_URL_STAGING
-        ? API_SERVER_URL_PROD
+        ? // ? API_SERVER_URL_STAGING
+          API_SERVER_URL_PROD
         : API_SERVER_URL_PROD
     }/--/api/v2/snack/uploadPreview`;
     const body = JSON.stringify({ asset, height, width });

--- a/runtime/src/Modules.tsx
+++ b/runtime/src/Modules.tsx
@@ -268,9 +268,12 @@ const fetchPipeline = async (load: Load) => {
           );
         } else {
           // In development, try fetching from staging cloudfront first
+          // FIXME: Right now always using production snackpub server for custom snack-runtime.
+          // We should find a way to support both custom snack-runtime and formal snack-runtime serving from EAS Update.
           const cloudFrontUrls =
             Constants.manifest?.extra?.cloudEnv !== 'production'
-              ? [SNACKAGER_CDN_STAGING, SNACKAGER_CDN_PROD]
+              // ? [SNACKAGER_CDN_STAGING, SNACKAGER_CDN_PROD]
+              ? [SNACKAGER_CDN_PROD]
               : [SNACKAGER_CDN_PROD];
           for (const url of cloudFrontUrls) {
             const fetchFrom = `${url}/${handle}-${Platform.OS}/bundle.js`;

--- a/runtime/src/Modules.tsx
+++ b/runtime/src/Modules.tsx
@@ -272,8 +272,8 @@ const fetchPipeline = async (load: Load) => {
           // We should find a way to support both custom snack-runtime and formal snack-runtime serving from EAS Update.
           const cloudFrontUrls =
             Constants.manifest?.extra?.cloudEnv !== 'production'
-              // ? [SNACKAGER_CDN_STAGING, SNACKAGER_CDN_PROD]
-              ? [SNACKAGER_CDN_PROD]
+              ? // ? [SNACKAGER_CDN_STAGING, SNACKAGER_CDN_PROD]
+                [SNACKAGER_CDN_PROD]
               : [SNACKAGER_CDN_PROD];
           for (const url of cloudFrontUrls) {
             const fetchFrom = `${url}/${handle}-${Platform.OS}/bundle.js`;

--- a/runtime/src/utils/ExpoApiUtils.ts
+++ b/runtime/src/utils/ExpoApiUtils.ts
@@ -17,11 +17,18 @@ export type SnackApiCode = {
   };
 };
 
+/**
+ * Fetches a snack from the Snack API.
+ * @param snackIdentifier: The ID of snack, could be either in `@snack/<hashId>` or `@<username>/<hashId>` format.
+ */
 export async function fetchCodeBySnackIdentifier(
   snackIdentifier: string
 ): Promise<SnackApiCode | null> {
+  const snackId = snackIdentifier.startsWith('@snack/')
+    ? snackIdentifier.substring('@snack/'.length)
+    : snackIdentifier;
   try {
-    const res = await fetch(`https://exp.host/--/api/v2/snack/${snackIdentifier}`, {
+    const res = await fetch(`https://exp.host/--/api/v2/snack/${snackId}`, {
       method: 'GET',
       headers: {
         'Snack-Api-Version': '3.0.0',
@@ -29,7 +36,7 @@ export async function fetchCodeBySnackIdentifier(
     });
     return await res.json();
   } catch (err) {
-    Logger.error(`Failed fetch snack with identifier: ${snackIdentifier}`, err);
+    Logger.error(`Failed fetch snack with identifier: ${snackId}`, err);
   }
 
   return null;

--- a/runtime/src/utils/__tests__/ExpoApiUtils-test.ts
+++ b/runtime/src/utils/__tests__/ExpoApiUtils-test.ts
@@ -1,0 +1,23 @@
+import { fetchCodeBySnackIdentifier } from '../ExpoApiUtils';
+
+describe(fetchCodeBySnackIdentifier, () => {
+  let mockedFetch: jest.MockedFunction<typeof fetch>;
+  beforeEach(() => {
+    mockedFetch = jest.fn(() =>
+      Promise.resolve({
+        json: () => Promise.resolve({}),
+      })
+    ) as unknown as jest.MockedFunction<typeof fetch>;
+    globalThis.fetch = mockedFetch;
+  });
+
+  it('should support `@snack/<hashId>` format', async () => {
+    await fetchCodeBySnackIdentifier('@snack/foo');
+    expect(mockedFetch.mock.calls[0][0]).toBe('https://exp.host/--/api/v2/snack/foo');
+  });
+
+  it('should support `@username/<hashId>` format', async () => {
+    await fetchCodeBySnackIdentifier('@username/foo');
+    expect(mockedFetch.mock.calls[0][0]).toBe('https://exp.host/--/api/v2/snack/@username/foo');
+  });
+});


### PR DESCRIPTION
# Why

try to fix the snack fetching issue from draftbit shared page.

# How

if the loading experience url is `exp://exp.host/@snack/qzsyKKcbJ`, the original `fetchCodeBySnackIdentifier` will fetch `https://exp.host/--/api/v2/snack/@snack/qzsyKKcbJ` which returns 404. the correct url should be `https://exp.host/--/api/v2/snack/qzsyKKcbJ`.

# Test Plan

```
 PASS  src/utils/__tests__/ExpoApiUtils-test.ts
  fetchCodeBySnackIdentifier
    ✓ should support `@snack/<hashId>` format (2 ms)
    ✓ should support `@username/<hashId>` format
```